### PR TITLE
Feature/event channel created

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ Listen for when your bot gets mentioned across the workspace.
 
 - `filter_channel` - [Channel ID](#how-to-get-channel-id). If you want to filter down to a single channel. Example use case: `Workflow triggered by mentioning bot in a specific channel`.
 
+#### **channel_created** - [_docs_](https://api.slack.com/events/channel_created)
+
+- [x] happy path tested
+- [ ] template: `?`.
+
+Listen for new channels being created.
+
 #### **reaction_added** - [_docs_](https://api.slack.com/events/reaction_added)
 
 - [x] happy path tested

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Listen for when your bot gets mentioned across the workspace.
 #### **channel_created** - [_docs_](https://api.slack.com/events/channel_created)
 
 - [x] happy path tested
-- [ ] template: `?`.
+- [x] template: `event_trigger_example_workflows/trigger_channel_created.slackworkflow`
 
 Listen for new channels being created.
 

--- a/constants.py
+++ b/constants.py
@@ -13,7 +13,7 @@ EVENT_WORKFLOW_STEP_DELETED = "workflow_step_deleted"
 WORKFLOW_STEP_UTILS_CALLBACK_ID = "utilities"
 WORKFLOW_STEP_WEBHOOK_CALLBACK_ID = "outgoing_webhook"
 
-TIME_5_MINS = 5*60
+TIME_5_MINS = 5 * 60
 TIME_1_DAY = 24 * 3600
 
 APP_HOME_HEADER_BLOCKS = [
@@ -74,9 +74,9 @@ APP_HOME_HEADER_BLOCKS = [
         "elements": [
             {
                 "type": "mrkdwn",
-                "text": "_Alternatively get a Webhook URL from <https://webhook.site|Webhook.site> if you are just testing events are working._"
+                "text": "_Alternatively get a Webhook URL from <https://webhook.site|Webhook.site> if you are just testing events are working._",
             }
-        ]
+        ],
     },
     {
         "type": "section",
@@ -658,9 +658,11 @@ UTILS_CONFIG = {
                 "block_id": "channel_input",
                 "action_id": "channel_value",
             },
-            "post_at": {"block_id": "post_at_input",
-             "validation_type": "future_timestamp",
-             "action_id": "post_at_value"},
+            "post_at": {
+                "block_id": "post_at_input",
+                "validation_type": "future_timestamp",
+                "action_id": "post_at_value",
+            },
             "msg_text": {"block_id": "msg_text_input", "action_id": "msg_text_value"},
         },
         "outputs": [

--- a/event_trigger_example_workflows/trigger_channel_created.slackworkflow
+++ b/event_trigger_example_workflows/trigger_channel_created.slackworkflow
@@ -1,0 +1,120 @@
+{
+    "source_id": "428725752100304457",
+    "version": "1",
+    "workflow": {
+        "name": "Channel Created Trigger",
+        "blueprint": {
+            "version": "1",
+            "trigger": {
+                "type": "webhook",
+                "id": "b4b66224-434f-428a-b9db-dbf544cc32ef",
+                "config": {
+                    "url": "",
+                    "variables": [
+                        {
+                            "type": "text",
+                            "key": "type",
+                            "client_id": "1d9e6e65-de76-4ff4-93a5-7d9be8945f51"
+                        },
+                        {
+                            "type": "text",
+                            "key": "channel_id",
+                            "client_id": "6fd56e8a-aa2f-4737-9fa9-875f1efeb3dd"
+                        },
+                        {
+                            "type": "text",
+                            "key": "channel_name",
+                            "client_id": "ae67dee7-97b1-4a9d-8860-701df2d1b4e1"
+                        },
+                        {
+                            "type": "text",
+                            "key": "channel_created",
+                            "client_id": "08c9f221-7c8e-43c4-953b-de4fd90fcf14"
+                        },
+                        {
+                            "type": "text",
+                            "key": "channel_creator",
+                            "client_id": "9c6286f1-e29f-4fc0-8580-1f03cfe8ffe4"
+                        }
+                    ],
+                    "revoked_token": false
+                }
+            },
+            "steps": [
+                {
+                    "type": "message",
+                    "id": "21da2643-a61f-4000-afb3-f89be571ff66",
+                    "config": {
+                        "user": {
+                            "value": "UMTUPT124"
+                        },
+                        "has_button": false,
+                        "message_text": "Channel created event happened:\ntype: {{b4b66224-434f-428a-b9db-dbf544cc32ef==1d9e6e65-de76-4ff4-93a5-7d9be8945f51==text}}\nchannel_id: {{b4b66224-434f-428a-b9db-dbf544cc32ef==6fd56e8a-aa2f-4737-9fa9-875f1efeb3dd==text}}\nchannel_name: {{b4b66224-434f-428a-b9db-dbf544cc32ef==ae67dee7-97b1-4a9d-8860-701df2d1b4e1==text}}\nchannel_created: {{b4b66224-434f-428a-b9db-dbf544cc32ef==08c9f221-7c8e-43c4-953b-de4fd90fcf14==text}}\nchannel_creator: {{b4b66224-434f-428a-b9db-dbf544cc32ef==9c6286f1-e29f-4fc0-8580-1f03cfe8ffe4==text}}",
+                        "message_blocks": [
+                            {
+                                "type": "rich_text",
+                                "elements": [
+                                    {
+                                        "type": "rich_text_section",
+                                        "elements": [
+                                            {
+                                                "text": "Channel created event happened:\ntype: ",
+                                                "type": "text"
+                                            },
+                                            {
+                                                "type": "workflowtoken",
+                                                "id": "b4b66224-434f-428a-b9db-dbf544cc32ef==1d9e6e65-de76-4ff4-93a5-7d9be8945f51==text",
+                                                "property": "",
+                                                "data_type": "text"
+                                            },
+                                            {
+                                                "text": "\nchannel_id: ",
+                                                "type": "text"
+                                            },
+                                            {
+                                                "type": "workflowtoken",
+                                                "id": "b4b66224-434f-428a-b9db-dbf544cc32ef==6fd56e8a-aa2f-4737-9fa9-875f1efeb3dd==text",
+                                                "property": "",
+                                                "data_type": "text"
+                                            },
+                                            {
+                                                "text": "\nchannel_name: ",
+                                                "type": "text"
+                                            },
+                                            {
+                                                "type": "workflowtoken",
+                                                "id": "b4b66224-434f-428a-b9db-dbf544cc32ef==ae67dee7-97b1-4a9d-8860-701df2d1b4e1==text",
+                                                "property": "",
+                                                "data_type": "text"
+                                            },
+                                            {
+                                                "text": "\nchannel_created: ",
+                                                "type": "text"
+                                            },
+                                            {
+                                                "type": "workflowtoken",
+                                                "id": "b4b66224-434f-428a-b9db-dbf544cc32ef==08c9f221-7c8e-43c4-953b-de4fd90fcf14==text",
+                                                "property": "",
+                                                "data_type": "text"
+                                            },
+                                            {
+                                                "text": "\nchannel_creator: ",
+                                                "type": "text"
+                                            },
+                                            {
+                                                "type": "workflowtoken",
+                                                "id": "b4b66224-434f-428a-b9db-dbf544cc32ef==9c6286f1-e29f-4fc0-8580-1f03cfe8ffe4==text",
+                                                "property": "",
+                                                "data_type": "text"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ gunicorn = "^20.1.0"
 pytest = "^7.1.3"
 black = "^22.8.0"
 
+[tool.pytest.ini_options]
+log_cli = 1
+log_cli_level = "INFO"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/tc.py
+++ b/tests/tc.py
@@ -1,0 +1,36 @@
+# test_constants, renamed to avoid issues with imports as `constants` or run as a test file as `test_constants` by pytest.
+
+# some pulled from Slack API examples, others direct from testing
+SLACK_DEMO_EVENTS = {
+    "app_mention": {
+        "type": "app_mention",
+        "user": "U061F7AUR",
+        "text": "<@U0LAN0Z89> is it everything a river should be?",
+        "ts": "1515449522.000016",
+        "channel": "C0LAN2Q65",
+        "event_ts": "1515449522000016",
+    },
+    "channel_created": {
+        "type": "channel_created",
+        "channel": {
+            "id": "C04659N6J0G",
+            "is_channel": True,
+            "name": "workflow-channel-created",
+            "name_normalized": "workflow-channel-created",
+            "created": 1665073074,
+            "creator": "UMTUPT124",
+            "is_shared": False,
+            "is_org_shared": False,
+            "context_team_id": "TKM6AU1FG",
+        },
+        "event_ts": "1665073075.112600",
+    },
+    "reaction_added": {
+        "type": "reaction_added",
+        "user": "U024BE7LH",
+        "reaction": "thumbsup",
+        "item_user": "U0G9QF9C6",
+        "item": {"type": "message", "channel": "C0G9QF9GZ", "ts": "1360782400.498405"},
+        "event_ts": "1360782804.083113",
+    },
+}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,6 @@
+# import app as sut
+
+# Very hard to test Bolt apps right now without spinning up a dev server and other junk, and not much documentation on how to.
+# Current easiest workaround is to put core functionality into other testable modules like `utils`.
+
+# Tracking -> https://github.com/slackapi/bolt-python/issues/380. June 2021, in Oct 2022 still not much real progress.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,16 +1,33 @@
 import utils as sut
+import logging
 import json
+import unittest.mock as mock
 import pytest
+import tests.tc as test_const
+
+test_logger = logging.getLogger("TestLogger")
+
+
+class FakeResponse:
+    def __init__(self, status_code, body) -> None:
+        self.status_code = status_code
+        self.body = body
+
 
 SLACK_WORKFLOW_BUILDER_WEBHOOK_VARIABLES_MAX = 20
 
-def assert_dict_is_flat(d: dict):
-    for k,v in d.items():
-        assert type(v) != dict
+
+def assert_dict_is_flat_and_all_keys_are_strings(d: dict):
+    # Got error when I sent an integer instead of string to Slack for a variable
+    # {"error":"invalid_webhook_format","ok":false,"response_metadata":{"messages":["[ERROR] invalid required field: 'channel_created'"]}}
+    for k, v in d.items():
+        assert type(v) == str, f"key:`{k}` was wrong type: {type(v)} vs str." # implicitly, not dict
+
 
 ###############################################
 # Tests
 ###############################################
+
 
 def test_is_valid_slack_channel_name_too_long():
     name = "a" * 81
@@ -63,19 +80,20 @@ def test_load_json_body_from_input_with_nested_json():
     body = sut.load_json_body_from_input_str(input_str)
     assert type(body) is dict
 
-def test_flatten_payload_reaction_added():
-    e = {
-        "type": "reaction_added",
-        "user": "U024BE7LH",
-        "reaction": "thumbsup",
-        "item_user": "U0G9QF9C6",
-        "item": {
-            "type": "message",
-            "channel": "C0G9QF9GZ",
-            "ts": "1360782400.498405"
-        },
-        "event_ts": "1360782804.083113"
-    }
-    new_payload = sut.flatten_payload_for_slack_workflow_builder(e)
-    assert len(new_payload.keys()) <= SLACK_WORKFLOW_BUILDER_WEBHOOK_VARIABLES_MAX
-    assert_dict_is_flat(new_payload)
+
+@pytest.mark.parametrize("name, event", list(test_const.SLACK_DEMO_EVENTS.items()))
+def test_flatten_payload(name, event):
+    new_payload = sut.flatten_payload_for_slack_workflow_builder(event)
+    num_keys = len(new_payload.keys())
+    assert num_keys <= SLACK_WORKFLOW_BUILDER_WEBHOOK_VARIABLES_MAX
+    assert num_keys > 2
+    assert_dict_is_flat_and_all_keys_are_strings(new_payload)
+
+
+
+@pytest.mark.parametrize("name, event", list(test_const.SLACK_DEMO_EVENTS.items()))
+@mock.patch("utils.send_webhook")
+def test_generic_event_proxy(patched_send, name, event):
+    # TODO: Gotta mock out DB for each run to actually test something useful, otherwise it's unkown what you're hitting
+    patched_send.return_value = FakeResponse(201, {"body": True})
+    sut.generic_event_proxy(test_logger, event, {})


### PR DESCRIPTION
## What was changed?

- Added template workflow for `channel_created` events - along with the flattening logic needed to send data through to Slack Workflow Builder.
- Updated unit tests, and moved `generic_event_proxy()` to utils since Slack Bolt apps are frustrating to unit test.
- Docs updates.
- Found 🐛 where if Slack event sends us an `integer`, we need to convert that to a string before sending to Workflow Builder or it breaks Slack.

## Why is this good for our users?

This is good because now users have an example for how to use `channel_created` as an event trigger, and squashed a potentially annoying bug when incoming Slack events are using types that aren't just strings.

## Attestation

Below you'll find a checklist. For each item on the list, check one option and delete the other.

- Tests
  - [x] Unit tests have been updated.
- Documentation
  - [x] Docs have been updated.

