### PR TITLE
Feature/upgrade webhook to any http request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 	poetry run python -m pytest -sv tests/
 
 generate-requirements:
-	poetry export -o requirements.txt
+	poetry export -o requirements.txt --without-hashes
 
 up:
 	docker compose up

--- a/app.py
+++ b/app.py
@@ -59,6 +59,15 @@ def update_blocks_with_previous_input_based_on_config(
                             block["element"]["initial_conversation"] = prev_input_value
                         elif curr_input_config.get("type") == "channels_select":
                             block["element"]["initial_channel"] = prev_input_value
+                        elif curr_input_config.get("type") == "static_select":
+                            block["element"]["initial_option"] = {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": prev_input_value.upper(),
+                                        "emoji": True
+                                    },
+                                    "value": prev_input_value
+                                }
                         elif curr_input_config.get("type") == "users_select":
                             block["element"]["initial_user"] = prev_input_value
                         elif curr_input_config.get("type") == "checkboxes":
@@ -795,6 +804,8 @@ def parse_values_from_input_config(
             value = values[block_id][action_id]["selected_conversation"]
         elif input_config.get("type") == "checkboxes":
             value = json.dumps(values[block_id][action_id]["selected_options"])
+        elif input_config.get("type") == "static_select":
+            value = values[block_id][action_id]["selected_option"]["value"]
         else:
             # plain-text input by default
             value = values[block_id][action_id]["value"]

--- a/app.py
+++ b/app.py
@@ -83,6 +83,10 @@ def update_blocks_with_previous_input_based_on_config(
                         else:
                             # assume plain_text_input cuz it's common
                             block["element"]["initial_value"] = prev_input_value or ""
+    else:
+        logging.debug(
+            "No previous inputs to reload, anything you see is happening because of bad coding."
+        )
 
 
 def build_scheduled_message_modal(client: slack_sdk.WebClient) -> dict:
@@ -511,7 +515,6 @@ def edit_utils(ack: Ack, step: dict, configure: Configure, logger: logging.Logge
     existing_inputs = copy.deepcopy(
         step["inputs"]
     )  # avoid potential issue when we delete from input dict
-    logger.debug(f"inbound STEP: {step}")
 
     blocks = copy.deepcopy(c.UTILS_STEP_MODAL_COMMON_BLOCKS)
     DEFAULT_ACTION = "webhook"
@@ -528,7 +531,8 @@ def edit_utils(ack: Ack, step: dict, configure: Configure, logger: logging.Logge
             },
         }
     )
-    blocks.extend(chosen_config_item["modal_input_blocks"])
+    # have to make sure we aren't accidentally editing config blocks in memory
+    blocks.extend(copy.deepcopy(chosen_config_item["modal_input_blocks"]))
     update_blocks_with_previous_input_based_on_config(
         blocks, chosen_action, existing_inputs, chosen_config_item
     )
@@ -802,7 +806,7 @@ def execute_utils(
 
 def edit_webhook(ack: Ack, step: dict, configure: Configure):
     ack()
-    existing_inputs = step["inputs"]
+    existing_inputs = copy.deepcopy(step["inputs"])
     blocks = copy.deepcopy(c.WEBHOOK_STEP_MODAL_COMMON_BLOCKS)
     chosen_config_item = c.UTILS_CONFIG["webhook"]
     blocks.append(
@@ -814,7 +818,8 @@ def edit_webhook(ack: Ack, step: dict, configure: Configure):
             },
         }
     )
-    blocks.extend(chosen_config_item["modal_input_blocks"])
+    # have to make sure we aren't accidentally editing config blocks in memory
+    blocks.extend(copy.deepcopy(chosen_config_item["modal_input_blocks"]))
     update_blocks_with_previous_input_based_on_config(
         blocks, "webhook", existing_inputs, chosen_config_item
     )

--- a/app.py
+++ b/app.py
@@ -34,6 +34,7 @@ def log_request(logger: logging.Logger, body: dict, next):
 def update_blocks_with_previous_input_based_on_config(
     blocks: list, chosen_action, existing_inputs: dict, action_config_item: dict
 ) -> None:
+    # TODO: workflow builder keeps pulling old input on the step even when you are creating it totally new 🤔
     # kinda a crappy way to fill out existing inputs into initial values, but fast enough
     if existing_inputs:
         for input_name, value_obj in existing_inputs.items():
@@ -61,13 +62,13 @@ def update_blocks_with_previous_input_based_on_config(
                             block["element"]["initial_channel"] = prev_input_value
                         elif curr_input_config.get("type") == "static_select":
                             block["element"]["initial_option"] = {
-                                    "text": {
-                                        "type": "plain_text",
-                                        "text": prev_input_value.upper(),
-                                        "emoji": True
-                                    },
-                                    "value": prev_input_value
-                                }
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": prev_input_value.upper(),
+                                    "emoji": True,
+                                },
+                                "value": prev_input_value,
+                            }
                         elif curr_input_config.get("type") == "users_select":
                             block["element"]["initial_user"] = prev_input_value
                         elif curr_input_config.get("type") == "checkboxes":
@@ -504,12 +505,13 @@ def update_app_home(event: dict, logger: logging.Logger, client: slack_sdk.WebCl
     client.views_publish(user_id=event["user"], view=app_home_view)
 
 
-def edit_utils(ack: Ack, step: dict, configure: Configure):
+def edit_utils(ack: Ack, step: dict, configure: Configure, logger: logging.Logger):
     # TODO: if I want to update modal, need to listen for the action/event separately
     ack()
     existing_inputs = copy.deepcopy(
         step["inputs"]
     )  # avoid potential issue when we delete from input dict
+    logger.debug(f"inbound STEP: {step}")
 
     blocks = copy.deepcopy(c.UTILS_STEP_MODAL_COMMON_BLOCKS)
     DEFAULT_ACTION = "webhook"
@@ -604,7 +606,12 @@ def run_webhook(step: dict, complete: Complete, fail: Fail) -> None:
     inputs = step["inputs"]
     url = inputs["webhook_url"]["value"]
     bool_flags = {"fail_on_http_error": False}
+    http_method = inputs["http_method"]["value"]
     request_json_str = inputs.get("request_json_str", {}).get("value", {}) or "{}"
+    headers_json_str = inputs.get("headers_json_str", {}).get("value", {}) or "{}"
+    query_params_json_str = (
+        inputs.get("query_params_json_str", {}).get("value", {}) or "{}"
+    )
     logging.info(f"sending to url:{url}")
     body = {}
     bool_flags_input = inputs.get("bool_flags", {})
@@ -633,7 +640,32 @@ def run_webhook(step: dict, complete: Complete, fail: Fail) -> None:
         )
         return
 
-    resp = utils.send_webhook(url, body)
+    try:
+        new_headers = utils.load_json_body_from_input_str(headers_json_str)
+    except json.JSONDecodeError:
+        logging.error(f"JSON Decoding error: {headers_json_str}")
+        fail(
+            error={
+                "message": f"Unable to parse JSON Headers when preparing to send webhook to {url}. String was: {request_json_str}."
+            }
+        )
+        return
+
+    try:
+        query_params = utils.load_json_body_from_input_str(query_params_json_str)
+    except json.JSONDecodeError:
+        logging.error(f"JSON Decoding error: {query_params_json_str}")
+        fail(
+            error={
+                "message": f"Unable to parse JSON Query Params when preparing to send webhook to {url}. String was: {request_json_str}."
+            }
+        )
+        return
+
+    logging.debug(f"Method:{http_method}|Headers:{new_headers}|QP:{query_params}")
+    resp = utils.send_webhook(
+        url, body, method=http_method, params=query_params, headers=new_headers
+    )
 
     if bool_flags["fail_on_http_error"] and resp.status_code > 300:
         fail(
@@ -811,34 +843,38 @@ def parse_values_from_input_config(
             value = values[block_id][action_id]["value"]
 
         validation_type = input_config.get("validation_type")
+        # have to consider that people can pass variables, which would mess with some of validation
+        value_has_workflow_variable = utils.includes_slack_workflow_variable(value)
         if validation_type == "json" and value:
             try:
                 json.loads(value)
             except Exception:
                 errors[block_id] = "Invalid JSON."
-        elif validation_type == "integer":
+        elif validation_type == "integer" and not value_has_workflow_variable:
             try:
                 int(value)
             except ValueError:
                 errors[block_id] = f"Must be a valid integer."
-        elif validation_type == "email":
+        elif validation_type == "email" and not value_has_workflow_variable:
             if "@" not in value:
                 errors[block_id] = f"Must be a valid email."
-        elif validation_type == "url":
+        elif validation_type == "url" and not value_has_workflow_variable:
             if not utils.is_valid_url(value):
                 errors[block_id] = f"Must be a valid URL with `http(s)://.`"
-        elif validation_type == "slack_channel_name":
+        elif (
+            validation_type == "slack_channel_name" and not value_has_workflow_variable
+        ):
             if not utils.is_valid_slack_channel_name(value):
                 errors[
                     block_id
                 ] = "Channel names may only contain lowercase letters, numbers, hyphens, underscores and be max 80 chars."
-        elif validation_type == "able_to_post":
+        elif validation_type == "able_to_post" and not value_has_workflow_variable:
             status = utils.test_if_bot_is_member(value, client)
             if status == "not_in_channel":
                 errors[
                     block_id
                 ] = f"Bot needs to be invited to the conversation before it can post."
-        elif validation_type == "future_timestamp":
+        elif validation_type == "future_timestamp" and not value_has_workflow_variable:
             # TODO: must be a valid integer
             try:
                 timestamp_int = int(value)

--- a/constants.py
+++ b/constants.py
@@ -376,6 +376,63 @@ UTILS_CONFIG = {
                 },
             },
             {
+                "type": "actions",
+                "block_id": "http_method_action_select",
+                "elements": [
+                    {
+                        "type": "static_select",
+                        "placeholder": {
+                            "type": "plain_text",
+                            "text": "HTTP Method",
+                            "emoji": True,
+                        },
+                        "initial_option": {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "POST",
+                                "emoji": True,
+                            },
+                            "value": "POST",
+                        },
+                        "options": [
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "POST",
+                                    "emoji": True,
+                                },
+                                "value": "POST",
+                            },
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "GET",
+                                    "emoji": True,
+                                },
+                                "value": "GET",
+                            },
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "PUT",
+                                    "emoji": True,
+                                },
+                                "value": "PUT",
+                            },
+                            {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "DELETE",
+                                    "emoji": True,
+                                },
+                                "value": "DELETE",
+                            },
+                        ],
+                        "action_id": "http_method_action_select_value",
+                    }
+                ],
+            },
+            {
                 "type": "input",
                 "block_id": "request_json_str_input",
                 "optional": True,
@@ -403,6 +460,44 @@ UTILS_CONFIG = {
                     }
                 ],
             },
+            {
+                "type": "input",
+                "block_id": "headers_json_str_input",
+                "optional": True,
+                "element": {
+                    "type": "plain_text_input",
+                    "multiline": True,
+                    "action_id": "headers_json_str_value",
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": '{\n    "Authorization": "Bearer ..."\n}',
+                    },
+                },
+                "label": {
+                    "type": "plain_text",
+                    "text": "Headers JSON",
+                    "emoji": True,
+                },
+            },
+            {
+                "type": "input",
+                "block_id": "query_params_json_str_input",
+                "optional": True,
+                "element": {
+                    "type": "plain_text_input",
+                    "multiline": True,
+                    "action_id": "query_params_json_str_value",
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": '{\n    "q": "abc"\n}',
+                    },
+                },
+                "label": {
+                    "type": "plain_text",
+                    "text": "Query Params JSON",
+                    "emoji": True,
+                },
+            },
         ],
         "inputs": {
             "webhook_url": {
@@ -417,11 +512,29 @@ UTILS_CONFIG = {
                 "block_id": "block_checkboxes",
                 "action_id": "action_checkboxes",
             },
+            "http_method": {
+                "name": "http_method",
+                "type": "static_select",
+                "block_id": "http_method_action_select",
+                "action_id": "http_method_action_select_value"
+            },
             "request_json_str": {
                 "name": "request_json_str",
                 "validation_type": "json",
                 "block_id": "request_json_str_input",
                 "action_id": "request_json_str_value",
+            },
+            "headers_json_str": {
+                "name": "headers_json_str",
+                "validation_type": "json",
+                "block_id": "headers_json_str_input",
+                "action_id": "headers_json_str_value",
+            },
+            "query_params_json_str": {
+                "name": "query_params_json_str",
+                "validation_type": "json",
+                "block_id": "query_params_json_str_input",
+                "action_id": "query_params_json_str_value",
             },
         },
         "outputs": [

--- a/constants.py
+++ b/constants.py
@@ -13,6 +13,8 @@ EVENT_WORKFLOW_STEP_DELETED = "workflow_step_deleted"
 WORKFLOW_STEP_UTILS_CALLBACK_ID = "utilities"
 WORKFLOW_STEP_WEBHOOK_CALLBACK_ID = "outgoing_webhook"
 
+DB_UNHANDLED_EVENTS_KEY = "unhandled_events"
+
 TIME_5_MINS = 5 * 60
 TIME_1_DAY = 24 * 3600
 
@@ -376,17 +378,26 @@ UTILS_CONFIG = {
                 },
             },
             {
-                "type": "actions",
+                "type": "input",
                 "block_id": "http_method_action_select",
-                "elements": [
-                    {
-                        "type": "static_select",
-                        "placeholder": {
+                "label": {"type": "plain_text", "text": "HTTP Method", "emoji": True},
+                "element": {
+                    "type": "static_select",
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "HTTP Method",
+                        "emoji": True,
+                    },
+                    "initial_option": {
+                        "text": {
                             "type": "plain_text",
-                            "text": "HTTP Method",
+                            "text": "POST",
                             "emoji": True,
                         },
-                        "initial_option": {
+                        "value": "POST",
+                    },
+                    "options": [
+                        {
                             "text": {
                                 "type": "plain_text",
                                 "text": "POST",
@@ -394,43 +405,33 @@ UTILS_CONFIG = {
                             },
                             "value": "POST",
                         },
-                        "options": [
-                            {
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "POST",
-                                    "emoji": True,
-                                },
-                                "value": "POST",
+                        {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "GET",
+                                "emoji": True,
                             },
-                            {
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "GET",
-                                    "emoji": True,
-                                },
-                                "value": "GET",
+                            "value": "GET",
+                        },
+                        {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "PUT",
+                                "emoji": True,
                             },
-                            {
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "PUT",
-                                    "emoji": True,
-                                },
-                                "value": "PUT",
+                            "value": "PUT",
+                        },
+                        {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "DELETE",
+                                "emoji": True,
                             },
-                            {
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "DELETE",
-                                    "emoji": True,
-                                },
-                                "value": "DELETE",
-                            },
-                        ],
-                        "action_id": "http_method_action_select_value",
-                    }
-                ],
+                            "value": "DELETE",
+                        },
+                    ],
+                    "action_id": "http_method_action_select_value",
+                },
             },
             {
                 "type": "input",
@@ -516,7 +517,7 @@ UTILS_CONFIG = {
                 "name": "http_method",
                 "type": "static_select",
                 "block_id": "http_method_action_select",
-                "action_id": "http_method_action_select_value"
+                "action_id": "http_method_action_select_value",
             },
             "request_json_str": {
                 "name": "request_json_str",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,95 +1,19 @@
-certifi==2022.6.15; python_version >= "3.7" and python_version < "4" \
-    --hash=sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412 \
-    --hash=sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d
-charset-normalizer==2.1.1; python_version >= "3.7" and python_version < "4" and python_full_version >= "3.6.0" \
-    --hash=sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845 \
-    --hash=sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
-click==8.1.3; python_version >= "3.7" \
-    --hash=sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48 \
-    --hash=sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e
-colorama==0.4.5; python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0" \
-    --hash=sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da \
-    --hash=sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4
-flask==2.2.2; python_version >= "3.7" \
-    --hash=sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526 \
-    --hash=sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b
-gunicorn==20.1.0; python_version >= "3.5" \
-    --hash=sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e \
-    --hash=sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
-idna==3.3; python_version >= "3.7" and python_version < "4" \
-    --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
-    --hash=sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d
-importlib-metadata==4.12.0; python_version < "3.8" and python_version >= "3.7" \
-    --hash=sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23 \
-    --hash=sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670
-itsdangerous==2.1.2; python_version >= "3.7" \
-    --hash=sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44 \
-    --hash=sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a
-jinja2==3.1.2; python_version >= "3.7" \
-    --hash=sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61 \
-    --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852
-markupsafe==2.1.1; python_version >= "3.7" \
-    --hash=sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812 \
-    --hash=sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a \
-    --hash=sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e \
-    --hash=sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5 \
-    --hash=sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4 \
-    --hash=sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f \
-    --hash=sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e \
-    --hash=sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933 \
-    --hash=sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6 \
-    --hash=sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417 \
-    --hash=sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02 \
-    --hash=sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a \
-    --hash=sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37 \
-    --hash=sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980 \
-    --hash=sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a \
-    --hash=sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3 \
-    --hash=sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a \
-    --hash=sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff \
-    --hash=sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a \
-    --hash=sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452 \
-    --hash=sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003 \
-    --hash=sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1 \
-    --hash=sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601 \
-    --hash=sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925 \
-    --hash=sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f \
-    --hash=sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88 \
-    --hash=sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63 \
-    --hash=sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1 \
-    --hash=sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7 \
-    --hash=sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a \
-    --hash=sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f \
-    --hash=sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6 \
-    --hash=sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77 \
-    --hash=sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603 \
-    --hash=sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7 \
-    --hash=sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135 \
-    --hash=sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96 \
-    --hash=sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c \
-    --hash=sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247 \
-    --hash=sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b
-python-dotenv==0.21.0; python_version >= "3.7" \
-    --hash=sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045 \
-    --hash=sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5
-requests==2.28.1; python_version >= "3.7" and python_version < "4" \
-    --hash=sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349 \
-    --hash=sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983
-slack-bolt==1.14.3; python_version >= "3.6" \
-    --hash=sha256:c99bf8bca2f9fbe21a2712ae319f0a26a86f715d54f44de61d55bd0f8c3d4d5a \
-    --hash=sha256:0be5a3f54bb5c0cbeea79d6ffc7130ddf3ca21a81bb7ba5bc3b5de2a6da56e1d
-slack-sdk==3.18.2; python_full_version >= "3.6.0" and python_version >= "3.6" \
-    --hash=sha256:d895fa191f2288d74cbbf20055be2f39c54397b3288c766fcd31e3f5828ef937 \
-    --hash=sha256:69befeadfbfc9238e85d0641c864cd12bfb162fbdf3e8f9eef30180f171ea675
-typing-extensions==4.3.0; python_version < "3.8" and python_version >= "3.7" \
-    --hash=sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02 \
-    --hash=sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6
-urllib3==1.26.12; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.7" \
-    --hash=sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997 \
-    --hash=sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e
-werkzeug==2.2.2; python_version >= "3.7" \
-    --hash=sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5 \
-    --hash=sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f
-zipp==3.8.1; python_version < "3.8" and python_version >= "3.7" \
-    --hash=sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009 \
-    --hash=sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2
+certifi==2022.6.15; python_version >= "3.7" and python_version < "4"
+charset-normalizer==2.1.1; python_version >= "3.7" and python_version < "4" and python_full_version >= "3.6.0"
+click==8.1.3; python_version >= "3.7"
+colorama==0.4.5; python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0"
+flask==2.2.2; python_version >= "3.7"
+gunicorn==20.1.0; python_version >= "3.5"
+idna==3.3; python_version >= "3.7" and python_version < "4"
+importlib-metadata==4.12.0; python_version < "3.8" and python_version >= "3.7"
+itsdangerous==2.1.2; python_version >= "3.7"
+jinja2==3.1.2; python_version >= "3.7"
+markupsafe==2.1.1; python_version >= "3.7"
+python-dotenv==0.21.0; python_version >= "3.7"
+requests==2.28.1; python_version >= "3.7" and python_version < "4"
+slack-bolt==1.14.3; python_version >= "3.6"
+slack-sdk==3.18.2; python_full_version >= "3.6.0" and python_version >= "3.6"
+typing-extensions==4.3.0; python_version < "3.8" and python_version >= "3.7"
+urllib3==1.26.12; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.7"
+werkzeug==2.2.2; python_version >= "3.7"
+zipp==3.8.1; python_version < "3.8" and python_version >= "3.7"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,6 +92,25 @@ def test_flatten_payload(name, event):
     assert_dict_is_flat_and_all_keys_are_strings(new_payload)
 
 
+@pytest.mark.parametrize(
+    "value, expected_result",
+    [
+        (
+            "I am a value with {{65591853-edfe-4721-856d-ecd157766461==user.name}} in it",
+            True,
+        ),
+        ("abc@example.com", False),
+        ("5", False),
+        (None, False),
+    ],
+)
+def test_includes_slack_workflow_variable(value, expected_result):
+    result = sut.includes_slack_workflow_variable(value)
+    assert (
+        result == expected_result
+    ), "Unexpected outcome when testing for Workflow variables."
+
+
 @pytest.mark.parametrize("name, event", list(test_const.SLACK_DEMO_EVENTS.items()))
 @mock.patch("utils.send_webhook")
 def test_generic_event_proxy(patched_send, name, event):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,9 @@ def assert_dict_is_flat_and_all_keys_are_strings(d: dict):
     # Got error when I sent an integer instead of string to Slack for a variable
     # {"error":"invalid_webhook_format","ok":false,"response_metadata":{"messages":["[ERROR] invalid required field: 'channel_created'"]}}
     for k, v in d.items():
-        assert type(v) == str, f"key:`{k}` was wrong type: {type(v)} vs str." # implicitly, not dict
+        assert (
+            type(v) == str
+        ), f"key:`{k}` was wrong type: {type(v)} vs str."  # implicitly, not dict
 
 
 ###############################################
@@ -88,7 +90,6 @@ def test_flatten_payload(name, event):
     assert num_keys <= SLACK_WORKFLOW_BUILDER_WEBHOOK_VARIABLES_MAX
     assert num_keys > 2
     assert_dict_is_flat_and_all_keys_are_strings(new_payload)
-
 
 
 @pytest.mark.parametrize("name, event", list(test_const.SLACK_DEMO_EVENTS.items()))

--- a/utils.py
+++ b/utils.py
@@ -71,9 +71,18 @@ def generic_event_proxy(logger: logging.Logger, event: dict, body: dict) -> None
     logger.info("Finished sending all webhooks for event")
 
 
-def send_webhook(url, body: dict) -> requests.Response:
+def send_webhook(
+    url: str,
+    body: dict,
+    method="POST",
+    params=None,
+    headers={"Content-Type": "application/json"},
+) -> requests.Response:
     logging.debug(f"body to send:{body}")
-    resp = requests.post(url, json=body)
+    print("METHOD:", method)
+    resp = requests.request(
+        method=method, url=url, json=body, params=params, headers=headers
+    )
     logging.info(f"{resp.status_code}: {resp.text}")
     return resp
 

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+from typing import Union
 import os
 import random
 import re
@@ -12,6 +13,7 @@ import slack_sdk
 import slack_sdk.errors
 from datetime import datetime, timedelta
 from pathlib import Path
+
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -51,7 +53,7 @@ def generic_event_proxy(logger: logging.Logger, event: dict, body: dict) -> None
         workflow_webhooks_to_request = db_get_event_config(event_type)
         db_remove_unhandled_event(event_type)
     except KeyError as e:
-        logger.exception(e)
+        logger.debug(f"KeyError - setting unhandled event for {event_type}:{e}")
         db_set_unhandled_event(event_type)
         return
 
@@ -89,14 +91,14 @@ def send_webhook(
 
 def db_get_unhandled_events() -> dict:
     try:
-        return IN_MEMORY_WRITE_THROUGH_CACHE["unhandled_events"]
+        return IN_MEMORY_WRITE_THROUGH_CACHE[c.DB_UNHANDLED_EVENTS_KEY]
     except KeyError:
         return []
 
 
 def db_remove_unhandled_event(event_type) -> None:
     try:
-        IN_MEMORY_WRITE_THROUGH_CACHE["unhandled_events"].remove(event_type)
+        IN_MEMORY_WRITE_THROUGH_CACHE[c.DB_UNHANDLED_EVENTS_KEY].remove(event_type)
         logging.info(f"Remove unhandled event: {event_type}")
         sync_cache_to_disk()
     except (ValueError, KeyError):
@@ -106,9 +108,9 @@ def db_remove_unhandled_event(event_type) -> None:
 def db_set_unhandled_event(event_type) -> None:
     logging.info(f"Adding unhandled event: {event_type}")
     try:
-        IN_MEMORY_WRITE_THROUGH_CACHE["unhandled_events"].append(event_type)
+        IN_MEMORY_WRITE_THROUGH_CACHE[c.DB_UNHANDLED_EVENTS_KEY].append(event_type)
     except KeyError:
-        IN_MEMORY_WRITE_THROUGH_CACHE["unhandled_events"] = [event_type]
+        IN_MEMORY_WRITE_THROUGH_CACHE[c.DB_UNHANDLED_EVENTS_KEY] = [event_type]
     sync_cache_to_disk()
 
 
@@ -166,6 +168,8 @@ def update_app_home(client, user_id, view=None) -> None:
 
 def build_app_home_view() -> dict:
     data = db_export()
+    curr_events = list(data.keys)
+    curr_events.remove(c.DB_UNHANDLED_EVENTS_KEY)
 
     blocks = copy.deepcopy(c.APP_HOME_HEADER_BLOCKS)
     unhandled_events = db_get_unhandled_events()
@@ -188,7 +192,7 @@ def build_app_home_view() -> dict:
                 },
             ]
         )
-    if len(data.keys()) < 1:
+    if len(curr_events) < 1:
         blocks.append(
             {
                 "type": "section",
@@ -199,7 +203,7 @@ def build_app_home_view() -> dict:
             }
         )
     for event_type, webhook_list in data.items():
-        if event_type == "unhandled_events":
+        if event_type == c.DB_UNHANDLED_EVENTS_KEY:
             continue
         single_event_row = [
             {
@@ -545,3 +549,12 @@ def flatten_payload_for_slack_workflow_builder(event):
         # TODO: gotta do this for other events, otherwise key info will be missed in nested objects
         flat_payload = event
     return flat_payload
+
+
+def includes_slack_workflow_variable(value: Union[str, None]) -> bool:
+    # Slack includes them like I am a value with {{65591853-edfe-4721-856d-ecd157766461==user.name}} in it
+    if value is None:
+        return False
+
+    pattern = "^.*{{.*==.*}}.*$"
+    return re.search(pattern, value) is not None


### PR DESCRIPTION
## What was changed?

- ⚡ Added new options for Outgoing webhook : `HTTP Method`, `Headers`, and `Query params` - now you can construct nearly any HTTP request you might need - especially ones needing Bearer auth tokens. Handles #24 .
- 🐛Should fix validation for #26  - but also for other types like `integer` that would have hit the same thing. It now ignores the validation if it sees a Workflow variable in the input.
- 🐛 Fix the randomly occurring inputs showing up from previous Steps when you were trying to create a fresh action, even across other Workflows. 
  - Was issue with Python constants dictionaries not being truly constant, so they were storing edits in memory.

## Why is this good for our users?

This is good because now you aren't blocked from sending more complex webhooks (most use cases beyond toy examples), and fixes bugs that were frustrating.

## Attestation

Below you'll find a checklist. For each item on the list, check one option and delete the other.

- Tests
  - [x ] Unit tests have been updated.
 
- Documentation
  - [x] This change does not need a documentation update
