### PR TITLE
Feature/handling unescaped json

### DIFF
--- a/app.py
+++ b/app.py
@@ -625,32 +625,50 @@ def run_webhook(step: dict, complete: Complete, fail: Fail) -> None:
             flag_name = box_item["value"]
             bool_flags[flag_name] = True
     except json.JSONDecodeError as e:
-        full_err_msg = f"Unable to parse JSON Flags when preparing to send webhook to {url}. Error: {str(e)}. Input was: {bool_flags_input}."
+        full_err_msg = utils.pretty_json_error_msg(
+            f"err111: Unable to parse JSON Flags when preparing to send webhook to {url}.",
+            bool_flags_input,
+            e,
+        )
         logging.error(full_err_msg)
         fail(error={"message": full_err_msg})
         return
 
     try:
-        body = utils.load_json_body_from_input_str(request_json_str)
+        body = utils.load_json_body_from_untrusted_input_str(request_json_str)
     except json.JSONDecodeError as e:
         # e.g. Expecting ':' delimiter: line 1 column 22 (char 21)
-        full_err_msg = f"Unable to parse JSON when preparing to send webhook to {url}.  Error: {str(e)}. Input was: {request_json_str}."
+        full_err_msg = utils.pretty_json_error_msg(
+            "err112: Unable to parse JSON when preparing to send webhook to {url}.",
+            bool_flags_input,
+            e,
+        )
         logging.error(full_err_msg)
         fail(error={"message": full_err_msg})
         return
 
     try:
-        new_headers = utils.load_json_body_from_input_str(headers_json_str)
+        new_headers = utils.load_json_body_from_untrusted_input_str(headers_json_str)
     except json.JSONDecodeError as e:
-        full_err_msg = f"Unable to parse JSON Headers when preparing to send webhook to {url}. Error: {str(e)}. Input was: {request_json_str}."
+        full_err_msg = utils.pretty_json_error_msg(
+            f"err113: Unable to parse JSON Headers when preparing to send webhook to {url}.",
+            bool_flags_input,
+            e,
+        )
         logging.error(full_err_msg)
         fail(error={"message": full_err_msg})
         return
 
     try:
-        query_params = utils.load_json_body_from_input_str(query_params_json_str)
+        query_params = utils.load_json_body_from_untrusted_input_str(
+            query_params_json_str
+        )
     except json.JSONDecodeError as e:
-        full_err_msg = f"Unable to parse JSON Query Params when preparing to send webhook to {url}. Error: {str(e)}. Input was: {request_json_str}."
+        full_err_msg = utils.pretty_json_error_msg(
+            f"err114: Unable to parse JSON Query Params when preparing to send webhook to {url}.",
+            bool_flags_input,
+            e,
+        )
         logging.error(full_err_msg)
         fail(error={"message": full_err_msg})
         return
@@ -874,7 +892,6 @@ def parse_values_from_input_config(
             try:
                 timestamp_int = int(value)
                 curr = datetime.now().timestamp()
-                print("DIFF:", timestamp_int - curr)
                 if (timestamp_int - curr) < c.TIME_5_MINS:
                     readable_bad_dt = str(datetime.fromtimestamp(timestamp_int))
                     errors[

--- a/app.py
+++ b/app.py
@@ -639,8 +639,8 @@ def run_webhook(step: dict, complete: Complete, fail: Fail) -> None:
     except json.JSONDecodeError as e:
         # e.g. Expecting ':' delimiter: line 1 column 22 (char 21)
         full_err_msg = utils.pretty_json_error_msg(
-            "err112: Unable to parse JSON when preparing to send webhook to {url}.",
-            bool_flags_input,
+            f"err112: Unable to parse JSON when preparing to send webhook to {url}.",
+            request_json_str,
             e,
         )
         logging.error(full_err_msg)
@@ -652,7 +652,7 @@ def run_webhook(step: dict, complete: Complete, fail: Fail) -> None:
     except json.JSONDecodeError as e:
         full_err_msg = utils.pretty_json_error_msg(
             f"err113: Unable to parse JSON Headers when preparing to send webhook to {url}.",
-            bool_flags_input,
+            headers_json_str,
             e,
         )
         logging.error(full_err_msg)
@@ -666,7 +666,7 @@ def run_webhook(step: dict, complete: Complete, fail: Fail) -> None:
     except json.JSONDecodeError as e:
         full_err_msg = utils.pretty_json_error_msg(
             f"err114: Unable to parse JSON Query Params when preparing to send webhook to {url}.",
-            bool_flags_input,
+            query_params_json_str,
             e,
         )
         logging.error(full_err_msg)

--- a/utils.py
+++ b/utils.py
@@ -90,8 +90,7 @@ def send_webhook(
     params=None,
     headers={"Content-Type": "application/json"},
 ) -> requests.Response:
-    logging.debug(f"body to send:{body}")
-    print("METHOD:", method)
+    logging.debug(f"Method:{method}. body to send:{body}")
     resp = requests.request(
         method=method, url=url, json=body, params=params, headers=headers
     )
@@ -274,13 +273,13 @@ def test_if_bot_is_member(conversation_id: str, client: slack_sdk.WebClient) -> 
         resp = client.conversations_info(
             channel=conversation_id,
         )
-        print(resp)
+        logging.debug(resp)
         if resp["channel"]["is_member"]:
             return "is_member"
         else:
             return "not_in_channel"
     except slack_sdk.errors.SlackApiError as e:
-        print(type(e).__name__, e)
+        logging.error(type(e).__name__, e)
         return "unable_to_test"
 
 
@@ -486,13 +485,45 @@ def sanitize_webhook_response(resp_text: str) -> str:
     return sanitized
 
 
-def load_json_body_from_input_str(input_str: str) -> dict:
+def clean_json_quotes(s: str) -> str:
+    # slack adding weird smart quotes on Mac, try to handle any smart quotes.
+    # Need to use this utility likely wherever we allow JSON input from users.
+    s = s.replace("“", '"')
+    s = s.replace("”", '"')
+    return s
+
+
+def sanitize_unescaped_quotes_and_load_json_str(s: str, strict=False) -> dict:
+    # TODO: one thing this doesn't handle, is if the unescaped text includes valid JSON - then you're just out of luck
+    js_str = s
+    prev_pos = -1
+    curr_pos = 0
+    while curr_pos > prev_pos:
+        # after while check, move marker before we overwrite it
+        prev_pos = curr_pos
+        try:
+            return json.loads(js_str, strict=strict)
+        except json.JSONDecodeError as err:
+            curr_pos = err.pos
+            if curr_pos <= prev_pos:
+                # previous change didn't make progress, so error
+                raise err
+
+            # find the previous " before e.pos
+            prev_quote_index = js_str.rfind('"', 0, curr_pos)
+            # escape it to \"
+            js_str = js_str[:prev_quote_index] + "\\" + js_str[prev_quote_index:]
+
+
+def load_json_body_from_untrusted_input_str(input_str: str) -> dict:
     # TODO: probably need a better handle on this, or make it very obvious to users that we will do it
     input_str = input_str.replace(
         '""', '"'
     )  # ran into JSON parsing issues when JSON string inside body string and Slack
     deny_control_characters = False
-    data = json.loads(input_str, strict=deny_control_characters)
+    data = sanitize_unescaped_quotes_and_load_json_str(
+        input_str, strict=deny_control_characters
+    )
 
     for k, v in data.items():
         convert_newline_to_list = k.startswith("__")
@@ -573,9 +604,6 @@ def includes_slack_workflow_variable(value: Union[str, None]) -> bool:
     return re.search(pattern, value) is not None
 
 
-def clean_json_quotes(s: str) -> str:
-    # slack adding weird smart quotes on Mac, try to handle any smart quotes.
-    # Need to use this utility likely wherever we allow JSON input from users.
-    s = s.replace("“", '"')
-    s = s.replace("”", '"')
-    return s
+def pretty_json_error_msg(prefix: str, orig_input: str, e: json.JSONDecodeError) -> str:
+    problem_area = f"{e.doc[e.pos-3:e.pos+4]}"
+    return f"{prefix} Error: {str(e)}\nProblem Area: ...{problem_area}...\nInput was: {orig_input}."

--- a/utils.py
+++ b/utils.py
@@ -605,5 +605,7 @@ def includes_slack_workflow_variable(value: Union[str, None]) -> bool:
 
 
 def pretty_json_error_msg(prefix: str, orig_input: str, e: json.JSONDecodeError) -> str:
-    problem_area = f"{e.doc[e.pos-3:e.pos+4]}"
-    return f"{prefix} Error: {str(e)}\nProblem Area: ...{problem_area}...\nInput was: {orig_input}."
+    start_index = e.pos-3
+    end_index = e.pos+4 # 1 extra cuz range is non-inclusive
+    problem_area = f"{e.doc[start_index:end_index]}"
+    return f"{prefix} Error: {str(e)}.\n|Problem Area(chars{start_index}-{end_index}):-->{problem_area}<--|\nInput was: {repr(orig_input)}."


### PR DESCRIPTION
## What was changed?

Our handling of JSON strings in the common use case (JSON string which has a variable rammed into it without escaping by Slack) leads to problem characters when we try to decode the JSON. This fix allows double quotes to exist in variables for workflows and still be inserted into a JSON string (like for Outgoing Webhooks step).

## Why is this good for our users?

This is good because... double quotes are an incredibly common use case to support.

## Attestation

Below you'll find a checklist. For each item on the list, check one option and delete the other.

- Tests
  - [x] Unit tests have been updated.

- Documentation
  - [x] This change does not need a documentation update
