### PR TITLE
Action: wait for webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ _You can get creative and do a lot with these building blocks, but what if you w
 - **About**
   - [Demo Videos](#demos)
   - [Available Event Triggers](#-available-triggers) - `+Many`
-  - [Available Steps](#-available-steps) - `+12`
+  - [Available Steps](#-available-steps) - `+13`
   - [Common Use Cases](#-use-cases)
 - **Quick Starts/ Installation** - 🎉 _test me out!_ 🧪
   - [Installing your own Buddy](#running-workflow-buddy) - (5-30 mins)
@@ -198,6 +198,23 @@ _Need multiple values? For now, you can just use this Step multiple times in a W
 ### Wait for human | approval | manual completion
 
 Many names to describe it. In short, have your workflow wait in an `In progress` state until a human has taken action to either `Complete`➡ and let the Workflow continue, or `Fail`❌ it and stop the flow.
+
+### Wait for Webhook/ HTTP Request
+
+Have your workflow wait in an `In progress` state until it receives a webhook from an external service. You can choose to either `Complete`➡ and let the Workflow continue, or `Fail`❌ it and stop the flow.
+
+Example body Workflow Buddy expects:
+
+```
+{
+  "execution_id": "4364223353762.667214953526.b8f41739087702effd5ac3b0b514006f",
+  "sk": "RTPLSJVIBcmCAUcnUtbI",
+  "mark_as_failed": true,
+  "err_msg": "My sevice blew up!"
+}
+```
+
+_How do you get the execution ID?_ When saving the step, you will define a URL for Workflow Buddy to send the required data to. You could also get it from the `Manual Complete` step if it better fits your use case.
 
 ### Random Integer
 

--- a/constants.py
+++ b/constants.py
@@ -34,6 +34,8 @@ DB_UNHANDLED_EVENTS_KEY = "unhandled_events"
 TIME_5_MINS = 5 * 60
 TIME_1_DAY = 24 * 3600
 
+WEBHOOK_SK_LENGTH = 20
+
 APP_HOME_HEADER_BLOCKS = [
     {
         "type": "header",
@@ -234,6 +236,7 @@ UTILS_ACTION_LABELS = {
     "random_uuid": "Random UUID",
     "random_member_picker": "Random Member Picker",
     "manual_complete": "Wait for Manual Complete",
+    "wait_for_webhook": "Wait for Webhook",
     "json_extractor": "Extract Values from JSON",
     "conversations_create": "Slack: Channels Create",
     "find_user_by_email": "Slack: Find User by Email",
@@ -333,6 +336,14 @@ UTILS_STEP_MODAL_COMMON_BLOCKS = [
                             "emoji": True,
                         },
                         "value": "manual_complete",
+                    },
+                    {
+                        "text": {
+                            "type": "plain_text",
+                            "text": UTILS_ACTION_LABELS["wait_for_webhook"],
+                            "emoji": True,
+                        },
+                        "value": "wait_for_webhook",
                     },
                     {
                         "text": {
@@ -1177,6 +1188,49 @@ UTILS_CONFIG = {
                 "name": "reaction",
                 "block_id": "reaction_input",
                 "action_id": "reaction_value",
+            },
+        },
+        "outputs": [],
+    },
+    "wait_for_webhook": {
+        "draft": False,
+        "step_name": "Wait for Webhook",
+        "step_image_url": URLS["images"]["bara_main_logo"],
+        "description": "Waits to receive a webhook from an external service before continuing.",
+        "modal_input_blocks": [
+            {
+                "type": "input",
+                "block_id": "destination_url_input",
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "destination_url_value",
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "https://webhook.site/abcdefghijk",
+                    },
+                },
+                "label": {
+                    "type": "plain_text",
+                    "text": "Destination URL",
+                    "emoji": True,
+                },
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "_Open <https://webhook.site|Webhook.site> to get a URL for debugging._",
+                    }
+                ],
+            },
+        ],
+        "inputs": {
+            "destination_url": {
+                "name": "destination_url",
+                "validation_type": "url",
+                "block_id": "destination_url_input",
+                "action_id": "destination_url_value",
             },
         },
         "outputs": [],


### PR DESCRIPTION
## What was changed?

Added a new action that lets us finish steps based on receiving a webhook.

## Why is this good for our users?

This is good because... it allows users to programmatically "delegate" actions to another service without finishing the workflow, then pick up right where they left off.

## Attestation

Below you'll find a checklist. For each item on the list, check one option and delete the other.

- Tests
  - [x] Unit tests have been updated.
- Documentation
  - [x] Docs have been updated.
