### PR TITLE
Differentiate integration test workflow between dev and prod apps so …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,5 +40,11 @@ shell-dev:
 deploy-dev:
 	fly deploy -a workflow-buddy-dev -c fly.dev.toml
 
+deploy-dev-local:
+	fly deploy -a workflow-buddy-dev -c fly.dev.toml --local-only
+
 deploy-prod:
 	fly deploy -a workflow-buddy -c fly.prod.toml
+
+deploy-prod-local:
+	fly deploy -a workflow-buddy -c fly.prod.toml --local-only

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ _You can get creative and do a lot with these building blocks, but what if you w
   - [Installing your own Buddy/ Self-hosting](#running-workflow-buddy) - (5-30 mins)
   - [(Beginner) Simple Workflow](#beginner-quickstart-create-a-simple-workflow) - (~10 mins)
   - [(Advanced) Try New Event Triggers](#advanced-quickstart-new-event-triggers) - (~25 mins)
-  - [(Advanced) Try New Steps](#advanced-quickstart-run-all-new-steps) - (~25 mins)
+  - [(Advanced) Try New Steps](#advanced-quickstart-run-new-steps) - (~25 mins)
 - [FAQ](#faq)
 - [Support](#support)
 - [Development](#development)
@@ -365,19 +365,20 @@ If everything was correct, you should receive a message with a random UUID value
 
 _If you are looking to explore more advanced concepts like Triggers or advanced Workflow Buddy Steps, check out the **Advanced Quickstarts** below. Otherwise feel free to keep poking around on your own in Workflow Builder. There's endless possibilities, so **automate everything!**_
 
-### Advanced Quickstart: Run All New Steps
+### Advanced Quickstart: Run New Steps
 
-Try out the new **Steps** by importing a Workflow that has all of them configured (except for ones that make changes to your Slack Workspace, like `Create a channel`. Don't want to cause any weird side-effects during your testing!).
+Try out the new **Steps** by importing a Workflow that has ~~all~~ most of them configured _(except for ones that make changes to your Slack Workspace, like `Create a channel`. Don't want to cause any weird side-effects during your testing!)_.
 
-> ℹ  _If you haven't yet, you'll need to get a [Buddy instance running + a Slack app](#running-workflow-buddy). Come back when you're ready._
+> ℹ  _If you haven't yet, you'll need to get a [Buddy instance running + a Slack app](#running-workflow-buddy) or install the Cloud version. Come back when you're ready._
 
 - Download the Workflow template from `test_workflows/workflow_buddy_end_to_end_test_read_only.slackworkflow`[(link)](https://github.com/happybara-io/WorkflowBuddy/blob/main/test_workflows/workflow_buddy_end_to_end_test_read_only.slackworkflow), which contains all the basic functionality of Workflow Buddy Steps.
 - Open Workflow Builder, `Import`, and `Publish` it!
 - Click the `Edit` button on each of the configured Steps in the Workflow so you can see how each available action is configured. **Several require updates:**
-  - You'll need to fill in a test email for `find by email`; do your own to start.
-  - In `Send a webhook`, update the URL to be `https://<your ngrok or server URL>/webhook` to hit your own Workflow Buddy server's extra endpoint.
+  - Invite your new `@WorkflowBuddy` app to the channel you attached the Workflow Shortcut to - otherwise, the `setTopic` action will fail.
+  - _(Optional)_ From the `@WorkflowBuddy` App Home, add a notification channel for failures - that way, if anything goes wrong during setup, you'll find out! Sadly, by default [Slack's Workflow Builder](app.slack.com/workflow-builder/) will fail silently.
   - In `Schedule message`, you'll likely need to update the `timestamp`.
-- Run the Workflow and check the outputted message for details of the execution.
+- 🏃‍♂️**Run the Workflow!**
+  - If you decided not to add failure notifications, or you haven't seen anything happening for ~3 mins, check in Workflow Builder's `Activity` tab to ensure that your execution is in progress - _it might be waiting for you to respond to a message!_
 
 ✅ **That's it!**
 

--- a/app.py
+++ b/app.py
@@ -795,9 +795,10 @@ def save_utils(
         if curr_action_config.get("step_image_url"):
             kwargs["step_image_url"] = curr_action_config["step_image_url"]
         if curr_action_config.get("step_name"):
-            # No size limit, it just pushes it off the screen. Newline supported as well.
-            debug_label = f"(DEBUG) " if debug_mode_enabled else ""
-            kwargs["step_name"] = f"{debug_label}{curr_action_config['step_name']}"
+            label = ("(DEBUG) " if debug_mode_enabled else "") + (
+                "(Dev) " if ENV.lower() != "prod" else ""
+            )
+            kwargs["step_name"] = f"{label}{curr_action_config['step_name']}"
         update(**kwargs)
 
 

--- a/buddy/step_actions.py
+++ b/buddy/step_actions.py
@@ -356,7 +356,7 @@ def run_set_channel_topic(
         )
     except slack_sdk.errors.SlackApiError as e:
         logger.error(e.response)
-        errmsg = f"Slack Error: unable to set channel topic. {e.response['error']}"
+        errmsg = f"Slack Error: unable to set channel topic for <#{conversation_id}> (conversation_id). {e.response['error']}"
         raise WorkflowStepFailError(errmsg)
 
 

--- a/slack_app_manifest.template.yml
+++ b/slack_app_manifest.template.yml
@@ -5,7 +5,7 @@ display_information:
 features:
   app_home:
     home_tab_enabled: true
-    messages_tab_enabled: false
+    messages_tab_enabled: true
     messages_tab_read_only_enabled: false
   bot_user:
     display_name: WorkflowBuddy

--- a/test_workflows/workflow_buddy_end_to_end_test_read_only-dev-app.slackworkflow
+++ b/test_workflows/workflow_buddy_end_to_end_test_read_only-dev-app.slackworkflow
@@ -55,7 +55,7 @@
                                     "label": "Random Int Text"
                                 }
                             ],
-                            "step_name": "(DEBUG) Random Integer",
+                            "step_name": "(DEBUG) (Dev) Random Integer",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo.png"
                         }
                     }
@@ -104,7 +104,7 @@
                                     "label": "Waited For"
                                 }
                             ],
-                            "step_name": "Wait/Pause"
+                            "step_name": "(Dev) Wait/Pause"
                         }
                     }
                 },
@@ -139,7 +139,7 @@
                                     "label": "Random UUID"
                                 }
                             ],
-                            "step_name": "Random UUID",
+                            "step_name": "(Dev) Random UUID",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo.png"
                         }
                     }
@@ -208,7 +208,7 @@
                                 }
                             },
                             "outputs": [],
-                            "step_name": "Set Channel Topic",
+                            "step_name": "(Dev) Set Channel Topic",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo_slack_badge.png"
                         }
                     }
@@ -255,7 +255,7 @@
                                     "label": "Selected User ID 1"
                                 }
                             ],
-                            "step_name": "Random Member Picker",
+                            "step_name": "(Dev) Random Member Picker",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo_slack_badge.png"
                         }
                     }
@@ -309,7 +309,7 @@
                                     "label": "Real Name"
                                 }
                             ],
-                            "step_name": "Find user by email",
+                            "step_name": "(Dev) Find user by email",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo_slack_badge.png"
                         }
                     }
@@ -348,7 +348,7 @@
                                     "label": "User Email"
                                 }
                             ],
-                            "step_name": "Get Email from User",
+                            "step_name": "(Dev) Get Email from User",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo_slack_badge.png"
                         }
                     }
@@ -393,7 +393,7 @@
                                     "label": "Scheduled Message ID"
                                 }
                             ],
-                            "step_name": "Schedule a message",
+                            "step_name": "(Dev) Schedule a message",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo_slack_badge.png"
                         }
                     }
@@ -457,7 +457,7 @@
                                     "label": "Webhook Response Text (Unsanitized JSON string)"
                                 }
                             ],
-                            "step_name": "Send a webhook",
+                            "step_name": "(Dev) Send a webhook",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo_webhook_badge.png"
                         }
                     }
@@ -499,7 +499,7 @@
                                     "label": "Extracted Data Matches"
                                 }
                             ],
-                            "step_name": "Extract Value from JSON",
+                            "step_name": "(Dev) Extract Value from JSON",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo.png"
                         }
                     }
@@ -580,7 +580,7 @@
                                     "label": "User ID"
                                 }
                             ],
-                            "step_name": "Find a Message",
+                            "step_name": "(Dev) Find a Message",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo.png"
                         }
                     }
@@ -616,7 +616,7 @@
                                 }
                             },
                             "outputs": [],
-                            "step_name": "Add Reaction",
+                            "step_name": "(Dev) Add Reaction",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo_slack_badge.png"
                         }
                     }
@@ -666,7 +666,7 @@
                                     "label": "Actioning User"
                                 }
                             ],
-                            "step_name": "Wait for Human",
+                            "step_name": "(Dev) Wait for Human",
                             "step_image_url": "https://s3.happybara.io/happybara/main_logo.png"
                         }
                     }

--- a/test_workflows/workflow_buddy_end_to_end_test_read_only-dev-app.slackworkflow
+++ b/test_workflows/workflow_buddy_end_to_end_test_read_only-dev-app.slackworkflow
@@ -26,8 +26,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -68,8 +68,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -116,8 +116,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -185,8 +185,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -221,8 +221,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -268,8 +268,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -322,8 +322,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -361,8 +361,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -406,8 +406,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -470,8 +470,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -512,8 +512,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -593,8 +593,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {
@@ -629,8 +629,8 @@
                             "name": "Workflow Buddy Utilities",
                             "type": "workflow_step_edit",
                             "payload": null,
-                            "action_id": "Aa04RQ39G2TB",
-                            "api_app_id": "A04R4RNLCBG",
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
                             "callback_id": "utilities"
                         },
                         "app_defined_config": {


### PR DESCRIPTION
…it's easy to import for others

## What was changed?

...

## Why is this good for our users?

This is good because... it's going to be less confusing to import a workflow connected to an actual app that's available in prod, vs a dev app which we don't provide uptime guarantees for.

## Attestation

Below you'll find a checklist. For each item on the list, check one option and delete the other.

- **Unit Tests**
  - [x] This PR does not require tests.
- **Documentation**
  - [x] This change does not need a documentation update.
- **Integration Testing**
  - [x] At minimum, ran the [./test_workflows/workflow_buddy_end_to_end_test_read_only.slackworkflow](https://github.com/happybara-io/WorkflowBuddy/blob/main/test_workflows/workflow_buddy_end_to_end_test_read_only.slackworkflow) workflow and it was both successfully completed & outputs looked correct (We don't have a way to assert that changes are correct yet).
