### PR TITLE
Add an simple HTTP testing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ _You can get creative and do a lot with these building blocks, but what if you w
   - [(Beginner) Simple Workflow](#beginner-quickstart-create-a-simple-workflow) - (~10 mins)
   - [(Advanced) Try New Event Triggers](#advanced-quickstart-new-event-triggers) - (~25 mins)
   - [(Advanced) Try New Steps](#advanced-quickstart-run-new-steps) - (~25 mins)
+- [Example Workflow Templates](#example-workflows)
 - [FAQ](#faq)
 - [Support](#support)
 - [Development](#development)
@@ -70,6 +71,12 @@ _Hate reading and would rather see videos of it in action?_
 
 - [A ~3min video demo](https://github.com/happybara-io/WorkflowBuddy/blob/main/demos/app_mention_e2e_flow.md) showing a [custom event](#-available-triggers) triggering a Workflow which runs the majority of the [available Step actions](#-available-steps).
 - [A ~3min video demo](https://github.com/happybara-io/WorkflowBuddy/blob/main/demos/importing-from-trigger-and-outgoing-webhooks.md) showing how to go from [downloaded template](#templates-for-event-triggers) to triggering a Workflow that sends an [`Outgoing Webhook`](#send-a-webhook), along with a bonus of showing how to [proxy slack events to another service](#proxy-slack-events-to-another-service).
+
+---
+
+## Example Workflows
+
+See the `test_workflows/` folder for example Workflow templates you can use either as a base for your own, or to see what is possible with Workflow Buddy.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1053,6 +1053,15 @@ def health():
     return jsonify({"ok": True}), 201
 
 
+@flask_app.route("/reflect", methods=["POST"])
+def reflect_body():
+    """
+    Reflects the request body to ease integration testing of workflows
+    """
+    request_body = request.get_json()
+    return request_body, 200
+
+
 @flask_app.route("/random-fail", methods=["GET"])
 def random_fail():
     # doesn't need to be all of them, just a random assortment of 4xx + 5xx

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+# Examples
+
+See the `test_workflows/` folder for example Workflow templates you can use either as a base for your own, or to see what is possible with Workflow Buddy.
+
+## This seems redundant
+
+There are websites & other areas that would be mildly annoying to update if I change the `test_workflows/` folder name - so here we are. Not the worst sin I've possibly committed in this repo.

--- a/pysql.py
+++ b/pysql.py
@@ -19,7 +19,7 @@ def main(args: argparse.Namespace):
     query_stmt = args.sql_query
     print("[*] Running query", query_stmt)
     print("-------------------")
-    db_file_path = LOCAL_DB_FILE_PATH if args.local else DOCKER_FILE_PATH
+    db_file_path = (args.file or LOCAL_DB_FILE_PATH) if args.local else DOCKER_FILE_PATH
     if not os.path.isfile(db_file_path):
         raise ValueError(f"File doesnt exist!! -> {db_file_path}")
     conn_str = f"file:{db_file_path}?mode=ro"
@@ -41,5 +41,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog="pysql")
     parser.add_argument("sql_query")
     parser.add_argument("--local", "-l", action="store_true")
+    parser.add_argument(
+        "--file",
+        "-f",
+        default=LOCAL_DB_FILE_PATH,
+        help=f"Path to a local DB file (defaults to {LOCAL_DB_FILE_PATH})",
+    )
     args = parser.parse_args()
     main(args)

--- a/test_workflows/http_testing.slackworkflow
+++ b/test_workflows/http_testing.slackworkflow
@@ -1,0 +1,217 @@
+{
+    "source_id": "435001826144697082",
+    "version": "1",
+    "workflow": {
+        "name": "HTTP Testing",
+        "blueprint": {
+            "version": "1",
+            "trigger": {
+                "type": "channel_action",
+                "id": "30e79835-d2e4-46fa-b1ee-d4bc9d40cc5e",
+                "config": {
+                    "name": "HTTP Testing",
+                    "channels": [
+                        "CP1S57DAB"
+                    ],
+                    "callback_id": "9813059b-0443-4a50-8365-065ce4b8eb4a",
+                    "description": "HTTP Testing"
+                }
+            },
+            "steps": [
+                {
+                    "type": "extension_step",
+                    "id": "c24fb5dd-9642-4c0a-b4bb-92dccdff8a37",
+                    "config": {
+                        "app_action": {
+                            "name": "(Dev) Outgoing Webhook",
+                            "type": "workflow_step_edit",
+                            "payload": null,
+                            "action_id": "Aa04503AK8HF",
+                            "api_app_id": "A040W1RHGBX",
+                            "callback_id": "outgoing_webhook"
+                        },
+                        "app_defined_config": {
+                            "inputs": {
+                                "bool_flags": {
+                                    "value": "[{\"text\": {\"type\": \"mrkdwn\", \"text\": \" \", \"verbatim\": false}, \"value\": \"fail_on_http_error\", \"description\": {\"type\": \"mrkdwn\", \"text\": \"_Check this if you want Workflow to halt on server errors, otherwise it can continue._\", \"verbatim\": false}}]"
+                                },
+                                "http_method": {
+                                    "value": "POST"
+                                },
+                                "webhook_url": {
+                                    "value": "https://workflow-buddy-dev.fly.dev/reflect"
+                                },
+                                "headers_json_str": {
+                                    "value": null
+                                },
+                                "request_json_str": {
+                                    "value": "{\n   \"number\": 5,\n   \"nested\": {\n      \"abc\":  123\n   },\n   \"a_list\": [\n         {\"id\": 1, \"val\": 1},\n         {\"id\": 2, \"val\": 2}\n      ]\n}"
+                                },
+                                "query_params_json_str": {
+                                    "value": null
+                                }
+                            },
+                            "outputs": [
+                                {
+                                    "name": "webhook_status_code",
+                                    "type": "text",
+                                    "label": "Webhook Status Code"
+                                },
+                                {
+                                    "name": "webhook_response_text",
+                                    "type": "text",
+                                    "label": "Webhook Response Text"
+                                },
+                                {
+                                    "name": "webhook_response_text_unsanitized",
+                                    "type": "text",
+                                    "label": "Webhook Response Text (Unsanitized JSON string)"
+                                }
+                            ],
+                            "step_name": "Send a webhook",
+                            "step_image_url": "https://s3.happybara.io/happybara/main_logo_webhook_badge.png"
+                        }
+                    }
+                },
+                {
+                    "type": "extension_step",
+                    "id": "02150e5f-0b0a-4171-8db8-4df46aa65656",
+                    "config": {
+                        "app_action": {
+                            "name": "(Dev) Workflow Buddy Utilities",
+                            "type": "workflow_step_edit",
+                            "payload": null,
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
+                            "callback_id": "utilities"
+                        },
+                        "app_defined_config": {
+                            "inputs": {
+                                "json_string": {
+                                    "value": "{{c24fb5dd-9642-4c0a-b4bb-92dccdff8a37==webhook_response_text_unsanitized}}"
+                                },
+                                "jsonpath_expr": {
+                                    "value": "$.nested.abc"
+                                },
+                                "selected_utility": {
+                                    "value": "json_extractor"
+                                },
+                                "debug_mode_enabled": {
+                                    "value": "false"
+                                },
+                                "debug_conversation_id": {
+                                    "value": ""
+                                }
+                            },
+                            "outputs": [
+                                {
+                                    "name": "extracted_matches",
+                                    "type": "text",
+                                    "label": "Extracted Data Matches"
+                                }
+                            ],
+                            "step_name": "Extract Value from JSON",
+                            "step_image_url": "https://s3.happybara.io/happybara/main_logo.png"
+                        }
+                    }
+                },
+                {
+                    "type": "extension_step",
+                    "id": "5b70c94c-0784-48b4-a304-5432679191e0",
+                    "config": {
+                        "app_action": {
+                            "name": "(Dev) Workflow Buddy Utilities",
+                            "type": "workflow_step_edit",
+                            "payload": null,
+                            "action_id": "Aa041BLLURFB",
+                            "api_app_id": "A040W1RHGBX",
+                            "callback_id": "utilities"
+                        },
+                        "app_defined_config": {
+                            "inputs": {
+                                "json_string": {
+                                    "value": "{{c24fb5dd-9642-4c0a-b4bb-92dccdff8a37==webhook_response_text_unsanitized}}"
+                                },
+                                "jsonpath_expr": {
+                                    "value": "$.a_list[1].id"
+                                },
+                                "selected_utility": {
+                                    "value": "json_extractor"
+                                },
+                                "debug_mode_enabled": {
+                                    "value": "false"
+                                },
+                                "debug_conversation_id": {
+                                    "value": ""
+                                }
+                            },
+                            "outputs": [
+                                {
+                                    "name": "extracted_matches",
+                                    "type": "text",
+                                    "label": "Extracted Data Matches"
+                                }
+                            ],
+                            "step_name": "Extract Value from JSON",
+                            "step_image_url": "https://s3.happybara.io/happybara/main_logo.png"
+                        }
+                    }
+                },
+                {
+                    "type": "message",
+                    "id": "e0efc9c0-4e97-4ab8-bc6d-d7d08c4b51eb",
+                    "config": {
+                        "user": {
+                            "ref": "30e79835-d2e4-46fa-b1ee-d4bc9d40cc5e==user"
+                        },
+                        "has_button": false,
+                        "message_text": "{{c24fb5dd-9642-4c0a-b4bb-92dccdff8a37==webhook_response_text_unsanitized}}\nExtracted data: {{02150e5f-0b0a-4171-8db8-4df46aa65656==extracted_matches}}\n---\nSecond extraction: {{5b70c94c-0784-48b4-a304-5432679191e0==extracted_matches}}",
+                        "message_blocks": [
+                            {
+                                "type": "rich_text",
+                                "elements": [
+                                    {
+                                        "type": "rich_text_preformatted",
+                                        "elements": [
+                                            {
+                                                "id": "c24fb5dd-9642-4c0a-b4bb-92dccdff8a37==webhook_response_text_unsanitized",
+                                                "type": "workflowtoken",
+                                                "property": "",
+                                                "data_type": "text"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "rich_text_section",
+                                        "elements": [
+                                            {
+                                                "text": "Extracted data: ",
+                                                "type": "text"
+                                            },
+                                            {
+                                                "id": "02150e5f-0b0a-4171-8db8-4df46aa65656==extracted_matches",
+                                                "type": "workflowtoken",
+                                                "property": "",
+                                                "data_type": "text"
+                                            },
+                                            {
+                                                "text": "\n---\nSecond extraction: ",
+                                                "type": "text"
+                                            },
+                                            {
+                                                "id": "5b70c94c-0784-48b4-a304-5432679191e0==extracted_matches",
+                                                "type": "workflowtoken",
+                                                "property": "",
+                                                "data_type": "text"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## What was changed?

Small changes to a couple scripts, added a new endpoint that reflects the request body so we can easily have an integration test workflows for HTTP requests & Extracting JSON variables without depending on external servers.

## Why is this good for our users?

This is good because... improving testing.

## Attestation

Below you'll find a checklist. For each item on the list, check one option and delete the other.

- **Unit Tests**
  - [x] This PR does not require tests.
- **Documentation**
  - [x] Docs have been updated.
- **Integration Testing**
  - [-] At minimum, ran the [./test_workflows/workflow_buddy_end_to_end_test_read_only.slackworkflow](https://github.com/happybara-io/WorkflowBuddy/blob/main/test_workflows/workflow_buddy_end_to_end_test_read_only.slackworkflow) workflow and it was both successfully completed & outputs looked correct (We don't have a way to assert that changes are correct yet).
